### PR TITLE
Fixed telegram greeting message.

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -35,7 +35,7 @@ const handler = async context => {
     const {
       text
     } = context.event.message;
-    if (/^h(ello|i)/i.test(text)) {
+    if (/^h(ello|i)|^\/start/i.test(text)) {
       await platformReplyText(context, greetingMsg);
     } else if (text == "@@@") {
       const mem = process.memoryUsage();


### PR DESCRIPTION
When start taking with bot in telegram, the message "/start" will auto send to the bot.
So greeting message should also trigger with "/start" string.